### PR TITLE
Yl lp welcoming prompt

### DIFF
--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-
+import { Link } from 'react-router-dom';
 import { ListItem } from '../components';
 
 export function List({ data }) {
@@ -15,7 +15,7 @@ export function List({ data }) {
 		}
 	}, [data, itemSearch]);
 
-	return (
+	return data.length > 0 ? (
 		<>
 			<form>
 				<label htmlFor="itemSearch">Search your shopping list:</label>
@@ -41,5 +41,14 @@ export function List({ data }) {
 				})}
 			</ul>
 		</>
+	) : (
+		<div>
+			<p>
+				Welcome to your shopping list. Your Shopping List is currently empty!
+			</p>
+			<Link to={'/add-item'}>
+				<button>Add Item</button>
+			</Link>
+		</div>
 	);
 }


### PR DESCRIPTION
## Description
- When there are no items to display, the `List` view shows a welcome prompt and a button for the user to add their first item
- Once the button is clicked, it goes to the `Add Item` view for users to add items to their shopping list.  

## Related Issue

Closes #7 

## Acceptance Criteria

 

- [x] The list view, when there are no items to display, should show a prompt (e.g., a button) for the user to add their first item

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
<img width="627" alt="Screenshot 2023-04-26 at 3 31 18 PM" src="https://user-images.githubusercontent.com/112290188/234718886-2cddfe75-0402-4ef9-842f-03f6b520add9.png">

### After

![image](https://user-images.githubusercontent.com/112290188/234719002-86e34d64-f639-484b-a549-1286691fb7eb.png)

## Testing Steps / QA Criteria
- Remove list token => Make sure we start with an empty list => Go to the homepage, and we will see the welcome message and a button => When we click on the button, it will navigate to the `Add Item` view. 
- If the list is not empty => Navigate to the home screen, and we will see our shopping list and the search bar. 
