### PR TITLE
Implemented styles in add item view

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -4,3 +4,4 @@
 @use './sass/header.scss';
 @use './sass/home.scss';
 @use './sass/dark-mode.scss';
+@use './sass/add-item-view.scss';

--- a/src/sass/_add-item-view.scss
+++ b/src/sass/_add-item-view.scss
@@ -43,13 +43,7 @@
 				input[type='radio']:checked + label {
 					background: $purple;
 					color: $light-green;
-					box-shadow: 0px 0px 20px $yellow;
-				}
-
-				legend {
-					font-family: $header-font;
-					font-size: 2rem;
-					color: #ff404a;
+					border-color: $red-dark;
 				}
 
 				label {
@@ -60,18 +54,20 @@
 					align-items: center;
 					background: $yellow;
 					color: $brown;
-					box-shadow: 0px 3px 10px -2px hsla(150, 5%, 65%, 0.5);
+					border: 3px solid transparent;
 					position: relative;
+					transition: 0.3s;
+					&:hover,
+					&:focus {
+						border-color: $purple;
+						background-color: $purple;
+						color: $light-green;
+					}
 				}
 			}
 		}
 
-		.add-item-btn {
-			border: 0;
-			color: $brown;
-		}
-
-		.add-item-btn::before {
+		button::before {
 			position: absolute;
 			bottom: -10%;
 			left: 35%;

--- a/src/sass/_add-item-view.scss
+++ b/src/sass/_add-item-view.scss
@@ -1,0 +1,81 @@
+@use '_variables.scss' as *;
+
+.add-item-container {
+	position: relative;
+	align-items: center;
+	margin-bottom: 4em;
+
+	form {
+		.input {
+			display: flex;
+			flex-direction: column;
+			width: 75%;
+			margin: auto;
+		}
+
+		.input::after {
+			position: absolute;
+			top: 18%;
+			right: 4%;
+			content: url('/img/after.svg');
+		}
+
+		.item-urgency-container {
+			display: flex;
+			flex-direction: column;
+			padding: 30px 10px 0px 10px;
+
+			fieldset {
+				border: 0;
+				display: flex;
+				flex-direction: row;
+				flex-wrap: wrap;
+				justify-content: center;
+				padding: 30px;
+
+				input[type='radio'] {
+					display: none;
+					&:not(:disabled) ~ label {
+						cursor: pointer;
+					}
+				}
+
+				input[type='radio']:checked + label {
+					background: $purple;
+					color: $light-green;
+					box-shadow: 0px 0px 20px $yellow;
+				}
+
+				legend {
+					font-family: $header-font;
+					font-size: 2rem;
+					color: #ff404a;
+				}
+
+				label {
+					padding: 0.7em 1.1em;
+					margin: 0 0.3em 0.2em 0.3em;
+					border-radius: 15px;
+					display: flex;
+					align-items: center;
+					background: $yellow;
+					color: $brown;
+					box-shadow: 0px 3px 10px -2px hsla(150, 5%, 65%, 0.5);
+					position: relative;
+				}
+			}
+		}
+
+		.add-item-btn {
+			border: 0;
+			color: $brown;
+		}
+
+		.add-item-btn::before {
+			position: absolute;
+			bottom: -10%;
+			left: 35%;
+			content: url('/img/before.svg');
+		}
+	}
+}

--- a/src/sass/_fonts-general-styles.scss
+++ b/src/sass/_fonts-general-styles.scss
@@ -73,7 +73,8 @@ h2 {
 }
 
 //body fonts
-label {
+label,
+legend {
 	font-family: $header-font;
 	font-size: 2rem;
 	text-align: center;

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -79,52 +79,68 @@ export function AddItem({ data, listToken }) {
 	const handleFrequencyInput = (e) => setDaysUntilNextPurchase(+e.target.value);
 
 	return (
-		<form onSubmit={(e) => submitForm(e)}>
-			<label htmlFor="itemName">Item name:</label>
-			<input
-				type="text"
-				id="itemName"
-				name="itemName"
-				value={itemName}
-				onChange={handleNameInput}
-				required
-			/>
+		<div className="add-item-container">
+			<h2>Add an Item:</h2>
+			<form onSubmit={(e) => submitForm(e)}>
+				<div className="input">
+					<label htmlFor="itemName">Item name:</label>
+					<input
+						type="text"
+						id="itemName"
+						name="itemName"
+						value={itemName}
+						onChange={handleNameInput}
+						required
+					/>
+				</div>
 
-			<fieldset>
-				<legend htmlFor="itemFrequencyInDays">
-					How soon will you buy this again?
-				</legend>
-				<input
-					type="radio"
-					id="7"
-					name="itemFrequencyInDays"
-					value="7"
-					checked={daysUntilNextPurchase === 7}
-					onChange={handleFrequencyInput}
-				/>
-				<label htmlFor="7">Soon</label>
-				<input
-					type="radio"
-					id="14"
-					name="itemFrequencyInDays"
-					value="14"
-					checked={daysUntilNextPurchase === 14}
-					onChange={handleFrequencyInput}
-				/>
-				<label htmlFor="14">Kind of soon</label>
-				<input
-					type="radio"
-					id="30"
-					name="itemFrequencyInDays"
-					value="30"
-					checked={daysUntilNextPurchase === 30}
-					onChange={handleFrequencyInput}
-				/>
-				<label htmlFor="30">Not Soon</label>
-			</fieldset>
-
-			<button type="submit">Add Item</button>
-			<p>{submitStatus.value}</p>
-		</form>
+				<div className="item-urgency-container">
+					<fieldset>
+						<legend htmlFor="itemFrequencyInDays">
+							How soon will you buy this again?
+						</legend>
+						<input
+							type="radio"
+							id="7"
+							name="itemFrequencyInDays"
+							value="7"
+							checked={daysUntilNextPurchase === 7}
+							onChange={handleFrequencyInput}
+						/>
+						<label htmlFor="7">Soon</label>
+						<input
+							type="radio"
+							id="14"
+							name="itemFrequencyInDays"
+							value="14"
+							checked={daysUntilNextPurchase === 14}
+							onChange={handleFrequencyInput}
+						/>
+						<label htmlFor="14">
+							Kinda
+							<br />
+							soon
+						</label>
+						<input
+							type="radio"
+							id="30"
+							name="itemFrequencyInDays"
+							value="30"
+							checked={daysUntilNextPurchase === 30}
+							onChange={handleFrequencyInput}
+						/>
+						<label htmlFor="30">
+							Not
+							<br />
+							Soon
+						</label>
+					</fieldset>
+				</div>
+				<button type="submit" className="add-item-btn">
+					Add
+				</button>
+				<p>{submitStatus.value}</p>
+			</form>
+		</div>
 	);
 }

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -136,9 +136,7 @@ export function AddItem({ data, listToken }) {
 						</label>
 					</fieldset>
 				</div>
-				<button type="submit" className="add-item-btn">
-					Add
-				</button>
+				<button type="submit">Add</button>
 				<p>{submitStatus.value}</p>
 			</form>
 		</div>


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description

- style add item view to match wireframe
- when user clicks the "add item" button the little blue flourish moves below the success/error message. Let me know if you would prefer to have something different happen.

## Related Issue

closes #32 

## Acceptance Criteria

- Matches the wireframe

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|    | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|  ✓   | 🎨  Add styling            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

<img width="1109" alt="Screenshot 2023-05-24 at 10 19 29 PM" src="https://github.com/the-collab-lab/tcl-61-smart-shopping-list/assets/29443697/3de1be1c-3cbc-4a11-b20b-74bc8365527a">


### After

<img width="1084" alt="Screenshot 2023-05-24 at 10 18 37 PM" src="https://github.com/the-collab-lab/tcl-61-smart-shopping-list/assets/29443697/d9487137-debb-4be3-9031-856f4a6a277c">

## Testing Steps / QA Criteria

- Navigate to "Add item"
- Try adding a new item and try toggling between "soon," "kind of soon", and "not soon"
- Try adding an item that has already been added to your list.
