### PR TITLE
Add setTimeout to all success and error messages in AddItem

### DIFF
--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -33,24 +33,20 @@ export function AddItem({ data, listToken }) {
 		return false;
 	};
 
-	const setStatusWithTimeout = (value, delay) => {
-		setSubmitStatus({ type: 'error', value });
-		setTimeout(() => {
-			setSubmitStatus({ type: 'idle', value: '' });
-		}, delay);
-	};
-
 	const addItemToList = async () => {
 		const normalizedItemName = normalizeText(itemName);
 
 		try {
 			// Checks if the item is already on the user's list.
 			if (checkIfItemExists(normalizedItemName)) {
-				setStatusWithTimeout('You already added this item to your list.', 3000);
+				setSubmitStatus({
+					type: 'error',
+					value: 'You already added this item to your list.',
+				});
 
 				// Checks if the user is trying to submit an empty item.
 			} else if (normalizedItemName === '') {
-				setStatusWithTimeout('Please enter an item.', 3000);
+				setSubmitStatus({ type: 'error', value: 'Please enter an item.' });
 			} else {
 				await addItem(listToken, {
 					itemName: itemName,
@@ -68,6 +64,11 @@ export function AddItem({ data, listToken }) {
 				value: 'Item is NOT saved in the database',
 			});
 		}
+
+		setTimeout(() => {
+			setSubmitStatus({ type: 'idle', value: '' });
+		}, 3000);
+
 		setItemName('');
 		setDaysUntilNextPurchase(7);
 	};


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description
- Before when the` 'Item was successfully saved to the database'` and `'Item is NOT saved in the database'` messages would pop up, the messages did not timeout. 
- Added `setTimeOut` function to all error and success messages in `AddItem views` to reset to idle after 3 seconds so the user experience is consistent. 
-  The `setStatusWithTimeout` function is removed, and the timeout logic is integrated directly into the `addItemToList` function.

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓    | :bug: Bug fix              |
|   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

https://github.com/the-collab-lab/tcl-61-smart-shopping-list/assets/97640502/ddf85f1d-7dab-436d-825b-10676f205405


<!-- If UI feature, take provide screenshots -->

### After

https://github.com/the-collab-lab/tcl-61-smart-shopping-list/assets/97640502/3b8ce8d7-d945-4d34-be95-44cc15c7a4e6


<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria
- head over to `AddItem` 
- Enter an item that exists in your list and expect a `'You already added this item to your list.'` message to pop up and disappear after 3 seconds. 
- Enter an item that does NOT exist yet and expect a `'Item was successfully saved to the database' `message and disappear after 3 seconds.  
- Enter a space ' ' or a '.'  and expect a `'Please enter an item.'` message to pop up and disappear after 3 seconds.

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->
